### PR TITLE
Extend support to Cisco IOS XRd

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,14 @@ jobs:
         with:
           channel: 'tip'
 
-      - name: "Check out repository code"
-        uses: actions/checkout@v4
+      - name: Set up env for containers
+        run: |
+          # IOS XRd
+          sudo sysctl -w fs.inotify.max_user_instances=64000
+          # cRPD
+          sudo apt-get update
+          sudo apt-get install -qy linux-modules-extra-$(uname -r)
+          sudo modprobe mpls_router mpls_gso vrf
 
       - name: "Install dependencies"
         run: |
@@ -22,8 +28,8 @@ jobs:
           sudo apt-get install -y libxml2-utils jq sshpass
           curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
 
-      - name: "Build NETCLICS"
-        run: just build
+      - name: "Check out repository code"
+        uses: actions/checkout@v4
 
       - name: "Check out licenses repo"
         uses: actions/checkout@v4
@@ -37,8 +43,11 @@ jobs:
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-      - name: "Start static instances (cRPD container)"
+      - name: "Start static instances (cRPD and XRd container)"
         run: just start-static-instances
+
+      - name: "Build NETCLICS"
+        run: just build
 
       - name: "Wait for cRPD to be ready"
         run: |
@@ -89,6 +98,22 @@ jobs:
 
       - name: "Test NETCONF error handling"
         run: just test-netconf-error
+
+      # IOS XRd Tests
+      - name: "Test IOS XRd CLI to Acton adata conversion"
+        run: just test-iosxrd-cli-to-acton-adata
+
+      - name: "Test IOS XRd CLI to CLI roundtrip"
+        run: just test-iosxrd-cli-to-cli
+
+      - name: "Test IOS XRd NETCONF to CLI conversion"
+        run: just test-iosxrd-netconf-to-cli
+
+      - name: "Test IOS XRd CLI to NETCONF conversion"
+        run: just test-iosxrd-cli-to-netconf
+
+      - name: "Test IOS XRd CLI to JSON conversion"
+        run: just test-iosxrd-cli-to-json
 
       # MCP Protocol Tests
       - name: "Test MCP initialize"

--- a/Justfile
+++ b/Justfile
@@ -18,12 +18,18 @@ build-ldep:
 
 IMAGE_PATH := env_var_or_default("IMAGE_PATH", "ghcr.io/orchestron-orchestrator/")
 
-start-static-instances:
-    docker run -d --name crpd1 --rm --privileged --publish 42830:830 --publish 42022:22 -v ./test/crpd-startup.conf:/juniper.conf -v ./router-licenses/juniper_crpd24.lic:/config/license/juniper_crpd24.lic {{IMAGE_PATH}}crpd:24.4R1.9
+start-static-instances-crpd:
+    docker run -td --name crpd1 --rm --privileged --publish 42830:830 --publish 42022:22 -v ./test/crpd-startup.conf:/juniper.conf -v ./router-licenses/juniper_crpd24.lic:/config/license/juniper_crpd24.lic {{IMAGE_PATH}}crpd:24.4R1.9
     docker exec crpd1 cli -c "configure private; load merge /juniper.conf; commit"
 
+start-static-instances-xrd:
+    docker run -td --name xrd1 --rm --privileged --publish 43830:830 --publish 43022:22 -v ./test/xrd-startup.conf:/etc/xrd/first-boot.cfg --env XR_FIRST_BOOT_CONFIG=/etc/xrd/first-boot.cfg --env XR_MGMT_INTERFACES="linux:eth0,xr_name=Mg0/RP0/CPU0/0,chksum,snoop_v4,snoop_v6" {{IMAGE_PATH}}ios-xr/xrd-control-plane:24.1.1
+
+# Start both cRPD and XRD static instances
+start-static-instances: start-static-instances-crpd start-static-instances-xrd
+
 stop-static-instances:
-    docker stop crpd1
+    docker stop crpd1 xrd1 || true
 
 # Show available platforms
 platforms:

--- a/Justfile
+++ b/Justfile
@@ -258,6 +258,94 @@ test-mcp-instances:
 # MCP: Test all endpoints
 test-mcp-all: test-mcp-initialize test-mcp-tools-list test-mcp-platforms test-mcp-instances test-mcp-convert
 
+# Test IOS XRd CLI to Acton adata conversion
+test-iosxrd-cli-to-acton-adata:
+    #!/usr/bin/env bash
+    RESULT=$(curl -s -X POST http://localhost:8080/api/v1/convert \
+      -H "Content-Type: application/json" \
+      -d '{
+        "input": "interface GigabitEthernet0/0/0/1\n description \"IOS XRd test interface\"\n ipv4 address 10.1.1.1 255.255.255.0\n no shutdown",
+        "format": "cli",
+        "target_format": "acton-adata",
+        "platform": "iosxrd 24.1.1-local"
+      }')
+    echo "$RESULT" | jq .
+
+    echo ""
+    echo "=== Configuration Diff ==="
+    echo "$RESULT" | jq -r '.diff'
+
+# Test IOS XRd CLI to CLI roundtrip
+test-iosxrd-cli-to-cli:
+    #!/usr/bin/env bash
+    RESULT=$(curl -s -X POST http://localhost:8080/api/v1/convert \
+      -H "Content-Type: application/json" \
+      -d '{
+        "input": "interface GigabitEthernet0/0/0/2\n description \"IOS XRd CLI roundtrip\"\n ipv4 address 10.2.2.1 255.255.255.0\n no shutdown",
+        "format": "cli",
+        "target_format": "cli",
+        "platform": "iosxrd 24.1.1-local"
+      }')
+    echo "$RESULT" | jq .
+
+    echo ""
+    echo "=== Configuration Diff ==="
+    echo "$RESULT" | jq -r '.diff'
+
+# Test IOS XRd NETCONF to CLI conversion
+test-iosxrd-netconf-to-cli:
+    #!/usr/bin/env bash
+    RESULT=$(curl -s -X POST http://localhost:8080/api/v1/convert \
+      -H "Content-Type: application/json" \
+      -d '{
+        "input": "<configuration><interfaces xmlns=\"http://openconfig.net/yang/interfaces\"><interface><name>GigabitEthernet0/0/0/3</name><config><name>GigabitEthernet0/0/0/3</name><description>IOS XRd NETCONF test</description></config></interface></interfaces></configuration>",
+        "format": "netconf",
+        "target_format": "cli",
+        "platform": "iosxrd 24.1.1-local"
+      }')
+    echo "$RESULT" | jq .
+
+    echo ""
+    echo "=== Configuration Diff ==="
+    echo "$RESULT" | jq -r '.diff'
+
+# Test IOS XRd CLI to NETCONF conversion
+test-iosxrd-cli-to-netconf:
+    #!/usr/bin/env bash
+    RESULT=$(curl -s -X POST http://localhost:8080/api/v1/convert \
+      -H "Content-Type: application/json" \
+      -d '{
+        "input": "interface GigabitEthernet0/0/0/4\n description \"IOS XRd to NETCONF\"\n ipv4 address 10.4.4.1 255.255.255.0\n no shutdown",
+        "format": "cli",
+        "target_format": "netconf",
+        "platform": "iosxrd 24.1.1-local"
+      }')
+    echo "$RESULT" | jq .
+
+    echo ""
+    echo "=== Configuration Diff ==="
+    echo "$RESULT" | jq -r '.diff'
+
+# Test IOS XRd CLI to JSON conversion
+test-iosxrd-cli-to-json:
+    #!/usr/bin/env bash
+    RESULT=$(curl -s -X POST http://localhost:8080/api/v1/convert \
+      -H "Content-Type: application/json" \
+      -d '{
+        "input": "interface GigabitEthernet0/0/0/5\n description \"IOS XRd to JSON\"\n ipv4 address 10.5.5.1 255.255.255.0\n no shutdown",
+        "format": "cli",
+        "target_format": "json",
+        "platform": "iosxrd 24.1.1-local"
+      }')
+    echo "$RESULT" | jq .
+
+    echo ""
+    echo "=== Configuration Diff ==="
+    echo "$RESULT" | jq -r '.diff' | jq .
+
+# Run all IOS XRd tests
+test-iosxrd-all: test-iosxrd-cli-to-acton-adata test-iosxrd-cli-to-cli test-iosxrd-netconf-to-cli test-iosxrd-cli-to-netconf test-iosxrd-cli-to-json
+
 # Clean up build artifacts
 clean:
     rm -rf out/ .acton.lock *.log

--- a/src/netclics.act
+++ b/src/netclics.act
@@ -90,6 +90,7 @@ actor DeviceInstance(auth: WorldCap, log_handler: logging.Handler, platform_name
     var state = "starting"  # starting, ready, busy, stopping, error
     var started_at = 0  # Timestamp when started
     var last_used_at = 0  # Timestamp of last use
+    var device_platform = platform  # Store platform type for use in methods
 
     # Schema storage
     var compiled_schema: ?yang.schema.DRoot = None  # Compiled YANG schema
@@ -97,7 +98,7 @@ actor DeviceInstance(auth: WorldCap, log_handler: logging.Handler, platform_name
     var schema_ready = False  # Flag indicating schemas are ready
 
     # Set up logging
-    logh = logging.Handler("DeviceInstance")
+    logh = logging.Handler("DeviceInstance [{container_id}]")
     logh.set_handler(log_handler)
     _log = logging.Logger(logh)
 
@@ -117,7 +118,7 @@ actor DeviceInstance(auth: WorldCap, log_handler: logging.Handler, platform_name
         """Get device information for API responses"""
         instance_data = {
             "platform_name": platform_name,
-            "platform": platform,
+            "platform": device_platform,
             "instance_id": container_id,
             "ip_address": ip_address,
             "state": state,
@@ -555,8 +556,19 @@ actor DeviceInstance(auth: WorldCap, log_handler: logging.Handler, platform_name
             _log.error("CLI configuration failed", {"error": str(err), "response": response})
             callback(Exception("CLI configuration error: " + str(err)))
 
+
+        device_type = None
+        # Determine device type based on platform
+        if device_platform == "cisco_iosxr":
+            device_type = "cisco_iosxr"
+        elif device_platform == "junos":
+            device_type = "juniper_junos"
+        else:
+            callback(Exception("Unrecognized device platform: {device_platform}"))
+            return
+
         # Create router client
-        _log.info("Creating CLI client connection", {"host": ip_address, "port": ssh_port, "username": username})
+        _log.info("Creating CLI client connection", {"host": ip_address, "port": ssh_port, "username": username, "device_type": device_type})
         _log.debug("Password masked", {"password_length": len(password) if password is not None else 0})
 
         client = router_client.Client(
@@ -565,7 +577,7 @@ actor DeviceInstance(auth: WorldCap, log_handler: logging.Handler, platform_name
             username=username,
             password=password,
             port=ssh_port,
-            device_type="juniper_junos",  # Specify JUNOS device type
+            device_type=device_type,
             log_handler=log_handler
         )
 
@@ -610,8 +622,18 @@ actor DeviceInstance(auth: WorldCap, log_handler: logging.Handler, platform_name
                 _log.error("CLI config failed - received None response")
                 callback(None, Exception("CLI config failed"))
 
+        # Determine device type based on platform
+        device_type = None
+        if device_platform == "cisco_iosxr":
+            device_type = "cisco_iosxr"
+        elif device_platform == "junos":
+            device_type = "juniper_junos"
+        else:
+            callback(None, Exception("Unrecognized device platform: {device_platform}"))
+            return
+
         # Create router client
-        _log.info("Creating CLI utility client", {"host": ip_address, "port": ssh_port, "username": username})
+        _log.info("Creating CLI utility client", {"host": ip_address, "port": ssh_port, "username": username, "device_type": device_type})
         _log.debug("Password masked", {"password_length": len(password) if password is not None else 0})
 
         client = router_client.Client(
@@ -620,7 +642,7 @@ actor DeviceInstance(auth: WorldCap, log_handler: logging.Handler, platform_name
             username=username,
             password=password,
             port=ssh_port,
-            device_type="juniper_junos",  # Specify JUNOS device type
+            device_type=device_type,
             log_handler=log_handler
         )
 
@@ -758,8 +780,18 @@ actor DeviceInstance(auth: WorldCap, log_handler: logging.Handler, platform_name
             state = "ready"
             result_callback(None, Exception("CLI show configuration error: " + str(error)))
 
+        # Determine device type based on platform
+        device_type = None
+        if device_platform == "cisco_iosxr":
+            device_type = "cisco_iosxr"
+        elif device_platform == "junos":
+            device_type = "juniper_junos"
+        else:
+            result_callback(None, Exception("Unrecognized device platform: {device_platform}"))
+            return
+
         # Create router client
-        _log.info("Creating CLI client connection", {"host": ip_address, "port": ssh_port, "username": username})
+        _log.info("Creating CLI client connection", {"host": ip_address, "port": ssh_port, "username": username, "device_type": device_type})
         _log.debug("Password masked", {"password_length": len(password) if password is not None else 0})
 
         client = router_client.Client(
@@ -768,7 +800,7 @@ actor DeviceInstance(auth: WorldCap, log_handler: logging.Handler, platform_name
             username=username,
             password=password,
             port=ssh_port,
-            device_type="juniper_junos",  # Specify JUNOS device type
+            device_type=device_type,
             log_handler=log_handler
         )
 
@@ -830,8 +862,21 @@ actor DeviceInstance(auth: WorldCap, log_handler: logging.Handler, platform_name
                 _log.error("CLI diff failed - received None response")
                 result_callback(None, Exception("CLI diff failed"))
 
+        # Determine device type and diff command based on platform
+        device_type = None
+        diff_command = None
+        if device_platform == "cisco_iosxr":
+            device_type = "cisco_iosxr"
+            diff_command = "show configuration commit changes last 1"
+        elif device_platform == "junos":
+            device_type = "juniper_junos"
+            diff_command = "show configuration | compare rollback 1"
+        else:
+            result_callback(None, Exception("Unrecognized device platform: {device_platform}"))
+            return
+
         # Create router client
-        _log.info("Creating CLI client for diff", {"host": ip_address, "port": ssh_port, "username": username})
+        _log.info("Creating CLI client for diff", {"host": ip_address, "port": ssh_port, "username": username, "device_type": device_type})
         _log.debug("Password masked", {"password_length": len(password) if password is not None else 0})
 
         client = router_client.Client(
@@ -840,15 +885,20 @@ actor DeviceInstance(auth: WorldCap, log_handler: logging.Handler, platform_name
             username=username,
             password=password,
             port=ssh_port,
-            device_type="juniper_junos",  # Specify JUNOS device type
+            device_type=device_type,
             log_handler=log_handler
         )
 
         # Wait for connection and get diff
         def try_get_diff(attempt: int):
             if client.is_connected():
-                _log.debug("CLI client connected, sending diff command")
-                client.cmd(on_cmd_complete, "show configuration | compare rollback 1")
+                if diff_command is not None:
+                    _log.debug("CLI client connected, sending diff command", {"command": diff_command})
+                    client.cmd(on_cmd_complete, diff_command)
+                else:
+                    # This should never happen due to early return, but the compiler can't know that (yet?)
+                    result_callback(None, Exception("Invalid diff command"))
+                    return
             elif attempt < 10:  # Retry for up to 5 seconds (10 attempts * 500ms)
                 _log.debug("CLI client not ready for diff, retrying", {"attempt": attempt + 1})
                 after 0.5: try_get_diff(attempt + 1)
@@ -1070,6 +1120,11 @@ actor DeviceManager(config: SystemConfig, container_mgr: ContainerManager, auth:
     var pending_requests = []  # Requests waiting for a device
     var next_instance_id = 1
 
+    # Set up logging
+    logh = logging.Handler("DeviceManager")
+    logh.set_handler(log_handler)
+    _log = logging.Logger(logh)
+
     def count_instances(platform_name: str, state: ?str = None) -> int:
         """Count instances for a platform, optionally filtered by state"""
         # Simplified for now - just return length of instance_info
@@ -1116,11 +1171,20 @@ actor DeviceManager(config: SystemConfig, container_mgr: ContainerManager, auth:
 
     def get_device_for_request(platform_name: str) -> ?DeviceInstance:
         """Get or create a device for a request"""
-        # Simplified for now - just return first ready device
+        # Debug logging
+        _log.debug("Looking for device", {"requested_platform": platform_name, "total_instances": len(instances)})
+
+        # Find a ready device for the specified platform
         for i in range(len(instances)):
             device = instances[i]
-            if device.get_state() == "ready":
+            info = instance_info[i]
+            info_platform = info.get("platform_name")
+            device_state = device.get_state()
+            _log.debug("Checking device", {"index": i, "platform": str(info_platform), "state": device_state})
+            if device_state == "ready" and isinstance(info_platform, str) and info_platform == platform_name:
+                _log.info("Found matching device", {"platform": platform_name, "index": i})
                 return device
+        _log.warning("No matching device found", {"platform": platform_name})
         return None
 
     def start_device(platform: PlatformConfig) -> ?DeviceInstance:
@@ -1925,6 +1989,23 @@ def get_default_config() -> SystemConfig:
                     username="clab",
                     password="clab@123",
                     description="Local cRPD instance"
+                )
+            ]
+        ),
+        # Local Cisco IOS XRd static instance
+        PlatformConfig(
+            name="iosxrd 24.1.1-local",
+            platform="cisco_iosxr",
+            instances=[
+                InstanceSpec(
+                    id="local-iosxrd",
+                    host="127.0.0.1",
+                    netconf_port=43830,
+                    ssh_port=43022,
+                    restconf_port=32775,
+                    username="clab",
+                    password="clab@123",
+                    description="Local IOS XRd instance"
                 )
             ]
         ),

--- a/src/netclics.act
+++ b/src/netclics.act
@@ -1062,8 +1062,11 @@ actor DeviceInstance(auth: WorldCap, log_handler: logging.Handler, platform_name
                 if schema_data is not None:
                     schema_identifier = schema.identifier
                     if schema_identifier is not None:
-                        # Skip junos-rpc schemas as they're not needed, and also don't compile :/
-                        if schema_identifier.startswith("junos-rpc"):
+                        # Skip models:
+                        # - junos-rpc: all RPC modules use an undefined grouping?!
+                        # - openconfig: on Cisco IOS XRd openconfig-mpls.yang doesn't compile because submodule overrides prefix of parent import
+                        if schema_identifier.startswith("junos-rpc") or "openconfig" in schema_identifier:
+                            _log.debug("Skipping {schema_identifier}")
                             return
                         _log.debug("Downloaded schema", {"identifier": schema_identifier, "index": current_index + 1, "total": total_schemas})
                         schema_list.append(schema_data)

--- a/test/xrd-startup.conf
+++ b/test/xrd-startup.conf
@@ -1,0 +1,31 @@
+username clab
+ group root-lr
+ group cisco-support
+ secret 10 $6$IIpQZ1JBLtnJCZ1.$PeaudYh2DSlfw.C7rce0L80cZP.QqmUuwXNo0p.HiY5Be2znBCFtjdQEeZF.41ATw/C5eQ3Ax47H9ddh4ZOpX1
+!
+grpc
+ no-tls
+ address-family dual
+!
+line default
+ transport input ssh
+!
+netconf-yang agent
+ ssh
+!
+interface MgmtEth0/RP0/CPU0/0
+!
+interface GigabitEthernet0/0/0/0
+ shutdown
+!
+interface GigabitEthernet0/0/0/1
+ shutdown
+!
+interface GigabitEthernet0/0/0/2
+ shutdown
+!
+ssh server rate-limit 6000
+ssh server session-limit 110
+ssh server v2
+ssh server netconf vrf default
+end


### PR DESCRIPTION
Just like Juniper cRPD, we start a single static instance for now. Part of #11.