### PR TITLE
Make `start-static-instances` more reliable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,6 @@ jobs:
 
       - name: Set up env for containers
         run: |
-          # Disable AppArmor (interferes with creating dummy interfaces for Cisco IOS XRd)
-          sudo aa-teardown || true
-          sudo systemctl disable --now apparmor.service
           # IOS XRd
           sudo sysctl -w fs.inotify.max_user_instances=64000
           # cRPD

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: "Install dependencies"
         run: |
           sudo apt-get update
-          sudo apt-get install -y libxml2-utils jq sshpass
+          sudo apt-get install -y jq sshpass
           curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
 
       - name: "Check out repository code"

--- a/Justfile
+++ b/Justfile
@@ -44,6 +44,7 @@ start-static-instances-xrd:
         --env XR_INTERFACES="$XR_INTERFACES" \
         {{IMAGE_PATH}}ios-xr/xrd-control-plane:24.1.1
 
+    sleep 1
     # Create GigabitEthernet dummy interfaces (48 ports on slot 0)
     for port in {0..23}; do
         docker exec xrd1 ip link add Gi0-0-0-${port} type dummy


### PR DESCRIPTION
The error `OCI runtime exec failed: exec failed: unable to start container process: apparmor failed to apply profile: open /proc/thread-self/attr/apparmor/exec: read-only file system: unknown` sometimes appears when creating dummy interfaces in the XRd container. I could even sometimes reproduce the issue on my machine. Adding a tactical sleep sleep after creating the container seems to avoid some kind of race condition.