### PR TITLE
Fix list element removal in NETCONF XML

### DIFF
--- a/build.act.json
+++ b/build.act.json
@@ -2,8 +2,8 @@
     "dependencies": {
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",
-            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/3aad0a318f7f1b43daea987e04039c8a33a6cb5f.zip",
-            "hash": "122054b30686fc9387ec4be490f68c77704114bc00b9085bf2b8720ea03d57d3c31e"
+            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/1b2bfdf2aba8d5853d475d4c0a5bf769b71dd7af.zip",
+            "hash": "1220ca3841c1017c324a0a2a4b253b724e882703c72f0e932ec5a5d8fe6afbe6b05c"
         },
         "netconf": {
             "repo_url": "https://github.com/orchestron-orchestrator/netconf.git",


### PR DESCRIPTION
When removing (the only) Loopback interface list element, compute the correct NETCONF XML payload that doesn't remove the entire list but rather the element with key.