### PR TITLE
Missing leaf

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -695,3 +695,20 @@ test-multi-step-all: test-multi-step test-multi-step-iosxe test-multi-step-iosxr
 # Clean up build artifacts
 clean:
     rm -rf out/ .acton.lock *.log
+
+test-iosxrd-cli-to-acton-adata-missing-leaf:
+    #!/usr/bin/env bash
+    RESULT=$(curl -s -X POST http://localhost:8080/api/v1/convert \
+      -H "Content-Type: application/json" \
+      -d '{
+        "input": ["class-map match-all BE\n match cos inner 7\n end-class-map\n!\npolicy-map SAMPLE_POLICY\n class class-default\n  drop\n !\n end-policy-map\n!\npolicy-map FOOBAR\n class BE\n  police rate 10000 kbps burst 120 ms peak-burst 120 ms\n   exit\n  exit\n end-policy-map\n!"],
+        "format": "cli",
+        "target_format": "acton-adata",
+        "platform": "iosxrd 24.1.1-local",
+        "module_set": "cisco-xr-unified-model"
+      }')
+    echo "$RESULT" | jq .
+
+    echo ""
+    echo "=== Configuration Diff ==="
+    echo "$RESULT" | jq -r '.steps[0].diff'


### PR DESCRIPTION
See the `missing-leaf` branch/test. The `rate.value` leaf is missing, it is there if I switch to NETCONF/XML output. This is union in the model ... which I guess is somehow part of the problem?