### PR TITLE
Use rpcs to sync CLI and NETCONF datastore

### DIFF
--- a/src/netclics.act
+++ b/src/netclics.act
@@ -291,6 +291,26 @@ actor DeviceInstance(auth: WorldCap, log_handler: logging.Handler, platform_name
         # Start the first connection attempt
         attempt_connection()
 
+    def _get_credentials() -> ?(str, str):
+        """Get device credentials, returns (username, password) tuple or None"""
+        _log.debug("Checking device credentials")
+        if instance_spec is not None:
+            _log.debug("InstanceSpec found")
+            _username = instance_spec.username
+            _password = instance_spec.password
+            _log.debug("Checking username and password")
+            if _username is not None and _password is not None:
+                username = _username
+                password = _password
+                _log.info("Credentials found", {"username": username})
+                return (username, password)
+            else:
+                _log.error("Missing username or password for device", {"device": container_id, "username": str(_username), "password_set": str(True if _password is not None else False)})
+                return None
+        else:
+            _log.error("No InstanceSpec available for device", {"device": container_id})
+            return None
+
     def validate_module_set(module_set: str) -> ?str:
         """Validate if the requested module_set is available. Returns error message if invalid, None if valid."""
         if module_set == "":
@@ -478,6 +498,97 @@ actor DeviceInstance(auth: WorldCap, log_handler: logging.Handler, platform_name
 
             after 0.1: try_connect(0)
 
+    # IOS-XE cisco-ia namespace for sync operations
+    CISCO_IA_NS = "http://cisco.com/yang/cisco-ia"
+
+    def _iosxe_sync_from(callback: action(?Exception) -> None):
+        """Force IOS-XE to sync CLI config to NETCONF datastore via cisco-ia:sync-from RPC"""
+        _log.info("Triggering IOS-XE sync-from RPC")
+
+        def on_client_success(client: netconf.Client):
+            def on_rpc_done(client: netconf.Client, response: ?xml.Node, error: ?netconf.NetconfError):
+                if error is not None:
+                    _log.error("IOS-XE sync-from RPC failed", {"error": str(error)})
+                    callback(Exception(f"sync-from RPC failed: {error}"))
+                else:
+                    _log.info("IOS-XE sync-from RPC completed successfully")
+                    callback(None)
+
+            # Build cisco-ia:sync-from RPC
+            sync_from_node = xml.Node("sync-from", [(None, CISCO_IA_NS)], children=[])
+            client.rpc(sync_from_node, on_rpc_done)
+
+        def on_client_error(error: Exception):
+            _log.error("Failed to get NETCONF client for sync-from", {"error": str(error)})
+            callback(error)
+
+        _get_or_create_netconf_client(on_client_success, on_client_error)
+
+    def _iosxe_poll_sync_complete(callback: action(?Exception) -> None, max_attempts: int=30, poll_interval: float=1.0):
+        """Poll cisco-ia:is-syncing until sync is complete"""
+        _log.info("Polling IOS-XE is-syncing status")
+
+        def poll(attempt: int):
+            if attempt >= max_attempts:
+                _log.error("IOS-XE sync polling timed out", {"max_attempts": max_attempts})
+                callback(Exception(f"Sync polling timed out after {max_attempts} attempts"))
+                return
+
+            def on_client_success(client: netconf.Client):
+                def on_rpc_done(client: netconf.Client, response: ?xml.Node, error: ?netconf.NetconfError):
+                    if error is not None:
+                        _log.error("IOS-XE is-syncing RPC failed", {"error": str(error), "attempt": attempt + 1})
+                        callback(Exception(f"is-syncing RPC failed: {error}"))
+                        return
+
+                    # Parse response - look for <syncing> element with true/false value
+                    is_syncing: bool = False
+                    if response is not None:
+                        for child in response.children:
+                            if child.tag == "syncing":
+                                ct = child.text
+                                if ct is not None:
+                                    is_syncing = ct.lower() == "true"
+                                    _log.debug("is-syncing result", {"syncing": ct, "is_syncing": str(is_syncing)})
+                                break
+
+                    if is_syncing:
+                        _log.debug("IOS-XE still syncing, polling again", {"attempt": attempt + 1})
+                        after poll_interval: poll(attempt + 1)
+                    else:
+                        _log.info("IOS-XE sync complete", {"attempts": attempt + 1})
+                        callback(None)
+
+                # Build cisco-ia:is-syncing RPC
+                is_syncing_node = xml.Node("is-syncing", [(None, CISCO_IA_NS)], children=[])
+                client.rpc(is_syncing_node, on_rpc_done)
+
+            def on_client_error(error: Exception):
+                _log.error("Failed to get NETCONF client for is-syncing poll", {"error": str(error)})
+                callback(error)
+
+            _get_or_create_netconf_client(on_client_success, on_client_error)
+
+        poll(0)
+
+    def _iosxe_sync_and_get_config(module_set: str, callback: action(?(raw: xml.Node, gdata: yang.gdata.Node), ?Exception) -> None):
+        """Full IOS-XE sync workflow: sync-from -> poll is-syncing -> get-config"""
+        _log.info("Starting IOS-XE sync and config retrieval")
+
+        def on_sync_from_done(error: ?Exception):
+            if error is not None:
+                _log.warning("sync-from failed, continuing with poll", {"error": str(error)})
+            _iosxe_poll_sync_complete(on_poll_complete)
+
+        def on_poll_complete(error: ?Exception):
+            if error is not None:
+                _log.warning("Sync poll failed, attempting config retrieval anyway", {"error": str(error)})
+            _get_netconf_config_parsed(module_set, callback)
+
+        _iosxe_sync_from(on_sync_from_done)
+
+
+
     def _cleanup_conversion_clients():
         """Clean up persistent clients at end of conversion"""
         _log.info("Cleaning up conversion clients")
@@ -628,7 +739,13 @@ actor DeviceInstance(auth: WorldCap, log_handler: logging.Handler, platform_name
                 return
 
             _log.info("Step input applied successfully, retrieving configuration", {"step": current_step_index + 1})
-            _get_netconf_config_parsed(request.module_set, lambda config_tuple, error: on_step_config_retrieved(current_step_index, config_tuple, error))
+
+            # IOS-XE has a delay between CLI commit and NETCONF visibility.
+            # Use sync-from RPC and poll is-syncing to ensure consistency.
+            if device_platform == "cisco_iosxe" and request.format == "cli":
+                _iosxe_sync_and_get_config(request.module_set, lambda config_tuple, error: on_step_config_retrieved(current_step_index, config_tuple, error))
+            else:
+                _get_netconf_config_parsed(request.module_set, lambda config_tuple, error: on_step_config_retrieved(current_step_index, config_tuple, error))
 
         def on_step_config_retrieved(current_step_index: int, config_tuple: ?(raw: xml.Node, gdata: yang.gdata.Node), error: ?Exception):
             """Process the configuration after a step"""
@@ -1079,26 +1196,6 @@ actor DeviceInstance(auth: WorldCap, log_handler: logging.Handler, platform_name
         except Exception as e:
             _log.error("Failed to compute gdata diff", {"error": str(e)})
             return ""
-
-    def _get_credentials() -> ?(str, str):
-        """Get device credentials, returns (username, password) tuple or None"""
-        _log.debug("Checking device credentials")
-        if instance_spec is not None:
-            _log.debug("InstanceSpec found")
-            _username = instance_spec.username
-            _password = instance_spec.password
-            _log.debug("Checking username and password")
-            if _username is not None and _password is not None:
-                username = _username
-                password = _password
-                _log.info("Credentials found", {"username": username})
-                return (username, password)
-            else:
-                _log.error("Missing username or password for device", {"device": container_id, "username": str(_username), "password_set": str(True if _password is not None else False)})
-                return None
-        else:
-            _log.error("No InstanceSpec available for device", {"device": container_id})
-            return None
 
     def apply_netconf_config(config: str, config_name: str):
         """Generic method to apply NETCONF configuration to device"""


### PR DESCRIPTION
IOS-XE maintains two configuration views: the CLI running-config and the NETCONF datastore. These can become out of sync when changes are made via CLI.

Before performing NETCONF get-config to obtain changes that were done over CLI, we must ensure the NETCONF datastore reflects the current device state. The Cisco IOS-XE Infrastructure Agent (cisco-ia) provides RPCs for this:
1. cisco-ia:sync-from - Triggers synchronization from CLI running-config to NETCONF datastore
2. cisco-ia:is-syncing - Polls sync status until synchronization completes

For larger config snippets we often ended up in a situation where CLI to NETCONF conversion come back with missing config since sync was still running. By calling it explicitly and then polling the status of the sync we ensure up-to-date view of the datastores.

Log of this patch in action:
<details>
  <summary>Log of configuration change using new rpcs</summary>
<pre>
2026-01-08T13:59:35.259434891Z INFO   DeviceInstance [local-iosxe]: netclics.DeviceInstance[-56]: Step input applied successfully, retrieving configuration - {'step':1}
2026-01-08T13:59:35.259486441Z INFO   DeviceInstance [local-iosxe]: netclics.DeviceInstance[-56]: Starting IOS-XE sync and config retrieval
2026-01-08T13:59:35.259514373Z INFO   DeviceInstance [local-iosxe]: netclics.DeviceInstance[-56]: Triggering IOS-XE sync-from RPC
2026-01-08T13:59:35.259557196Z DEBUG  DeviceInstance [local-iosxe]: netclics.DeviceInstance[-56]: Reusing existing NETCONF client for conversion
2026-01-08T13:59:35.259732419Z DEBUG  netconf.Client[-29301]: Sending RPC - {'message-id':'2', 'content':<xml.Node object at 0x730cfc211910>}
2026-01-08T13:59:35.260164190Z TRACE  netconf.Client[-29301]: Sending chunk - {'chunk_size':125, 'chunk':b'<rpc xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\" message-id=\"2\"><sync-from xmlns=\"http://cisco.com/yang/cisco-ia\"/></rpc>'}
2026-01-08T13:59:35.409613915Z TRACE  netconf.Client[-29301]: MSG: - {'msg':'<?xml version="1.0" encoding="UTF-8"?>\n<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="2"><rpc-error>\n<error-type>application</error-type>\n<error-tag>resource-denied</error-tag>\n<error-severity>error</error-severity>\n<error-path xmlns:cisco-ia="http://cisco.com/yang/cisco-ia" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">\n    /nc:rpc/cisco-ia:sync-from\n  </error-path><error-message xml:lang="en">resource denied: Sync is in progress</error-message><error-info><bad-element>sync-from</bad-element>\n</error-info>\n</rpc-error>\n</rpc-reply>'}
2026-01-08T13:59:35.410307799Z ERROR  DeviceInstance [local-iosxe]: netclics.DeviceInstance[-56]: IOS-XE sync-from RPC failed - {'error':'netconf.NetconfError: resource denied: Sync is in progress'}
2026-01-08T13:59:35.410477379Z WARN   DeviceInstance [local-iosxe]: netclics.DeviceInstance[-56]: sync-from failed, continuing with poll - {'error':'Exception: sync-from RPC failed: netconf.NetconfError: resource denied: Sync is in progress'}
2026-01-08T13:59:35.410563098Z INFO   DeviceInstance [local-iosxe]: netclics.DeviceInstance[-56]: Polling IOS-XE is-syncing status
2026-01-08T13:59:35.410620154Z DEBUG  DeviceInstance [local-iosxe]: netclics.DeviceInstance[-56]: Reusing existing NETCONF client for conversion
2026-01-08T13:59:35.410815976Z DEBUG  netconf.Client[-29301]: Sending RPC - {'message-id':'3', 'content':<xml.Node object at 0x730cf9822500>}
2026-01-08T13:59:35.410915775Z TRACE  netconf.Client[-29301]: Sending chunk - {'chunk_size':126, 'chunk':b'<rpc xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\" message-id=\"3\"><is-syncing xmlns=\"http://cisco.com/yang/cisco-ia\"/></rpc>'}
2026-01-08T13:59:35.519850566Z TRACE  netconf.Client[-29301]: MSG: - {'msg':"""<?xml version="1.0" encoding="UTF-8"?>\n<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="3"><result xmlns='http://cisco.com/yang/cisco-ia'>Sync in progress. Reason: 'vrf forwarding Mgmt-intf ' CLI</result>\n<syncing xmlns='http://cisco.com/yang/cisco-ia'>true</syncing>\n<syncs-pending xmlns='http://cisco.com/yang/cisco-ia'>true</syncs-pending>\n<running-datastore-locked xmlns='http://cisco.com/yang/cisco-ia'>false</running-datastore-locked>\n</rpc-reply>"""}
2026-01-08T13:59:35.520484331Z DEBUG  DeviceInstance [local-iosxe]: netclics.DeviceInstance[-56]: is-syncing result - {'syncing':'true', 'is_syncing':'True'}
2026-01-08T13:59:35.520612142Z DEBUG  DeviceInstance [local-iosxe]: netclics.DeviceInstance[-56]: IOS-XE still syncing, polling again - {'attempt':1}
2026-01-08T13:59:36.519538979Z DEBUG  DeviceInstance [local-iosxe]: netclics.DeviceInstance[-56]: Reusing existing NETCONF client for conversion
2026-01-08T13:59:36.519770360Z DEBUG  netconf.Client[-29301]: Sending RPC - {'message-id':'4', 'content':<xml.Node object at 0x730cf6e1ce10>}
2026-01-08T13:59:36.519941878Z TRACE  netconf.Client[-29301]: Sending chunk - {'chunk_size':126, 'chunk':b'<rpc xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\" message-id=\"4\"><is-syncing xmlns=\"http://cisco.com/yang/cisco-ia\"/></rpc>'}
2026-01-08T13:59:36.546409302Z TRACE  netconf.Client[-29301]: MSG: - {'msg':"""<?xml version="1.0" encoding="UTF-8"?>\n<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="4"><result xmlns='http://cisco.com/yang/cisco-ia'>Sync in progress. Reason: 'vrf forwarding Mgmt-intf ' CLI</result>\n<syncing xmlns='http://cisco.com/yang/cisco-ia'>true</syncing>\n<syncs-pending xmlns='http://cisco.com/yang/cisco-ia'>true</syncs-pending>\n<running-datastore-locked xmlns='http://cisco.com/yang/cisco-ia'>false</running-datastore-locked>\n</rpc-reply>"""}
2026-01-08T13:59:36.547023982Z DEBUG  DeviceInstance [local-iosxe]: netclics.DeviceInstance[-56]: is-syncing result - {'syncing':'true', 'is_syncing':'True'}
2026-01-08T13:59:36.547180860Z DEBUG  DeviceInstance [local-iosxe]: netclics.DeviceInstance[-56]: IOS-XE still syncing, polling again - {'attempt':2}
2026-01-08T13:59:37.546158569Z DEBUG  DeviceInstance [local-iosxe]: netclics.DeviceInstance[-56]: Reusing existing NETCONF client for conversion
2026-01-08T13:59:37.546468961Z DEBUG  netconf.Client[-29301]: Sending RPC - {'message-id':'5', 'content':<xml.Node object at 0x730cf772b3c0>}
2026-01-08T13:59:37.546597502Z TRACE  netconf.Client[-29301]: Sending chunk - {'chunk_size':126, 'chunk':b'<rpc xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\" message-id=\"5\"><is-syncing xmlns=\"http://cisco.com/yang/cisco-ia\"/></rpc>'}
2026-01-08T13:59:37.587647537Z TRACE  netconf.Client[-29301]: MSG: - {'msg':"""<?xml version="1.0" encoding="UTF-8"?>\n<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="5"><result xmlns='http://cisco.com/yang/cisco-ia'>Sync in progress. Reason: 'vrf forwarding Mgmt-intf ' CLI</result>\n<syncing xmlns='http://cisco.com/yang/cisco-ia'>true</syncing>\n<syncs-pending xmlns='http://cisco.com/yang/cisco-ia'>true</syncs-pending>\n<running-datastore-locked xmlns='http://cisco.com/yang/cisco-ia'>false</running-datastore-locked>\n</rpc-reply>"""}
2026-01-08T13:59:37.588214445Z DEBUG  DeviceInstance [local-iosxe]: netclics.DeviceInstance[-56]: is-syncing result - {'syncing':'true', 'is_syncing':'True'}
2026-01-08T13:59:37.588314794Z DEBUG  DeviceInstance [local-iosxe]: netclics.DeviceInstance[-56]: IOS-XE still syncing, polling again - {'attempt':3}
2026-01-08T13:59:38.587545619Z DEBUG  DeviceInstance [local-iosxe]: netclics.DeviceInstance[-56]: Reusing existing NETCONF client for conversion
2026-01-08T13:59:38.587787902Z DEBUG  netconf.Client[-29301]: Sending RPC - {'message-id':'6', 'content':<xml.Node object at 0x730cf6e1c0f0>}
2026-01-08T13:59:38.587987392Z TRACE  netconf.Client[-29301]: Sending chunk - {'chunk_size':126, 'chunk':b'<rpc xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\" message-id=\"6\"><is-syncing xmlns=\"http://cisco.com/yang/cisco-ia\"/></rpc>'}
2026-01-08T13:59:38.614345955Z TRACE  netconf.Client[-29301]: MSG: - {'msg':"""<?xml version="1.0" encoding="UTF-8"?>\n<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="6"><result xmlns='http://cisco.com/yang/cisco-ia'>Sync in progress. Reason: 'vrf forwarding Mgmt-intf ' CLI</result>\n<syncing xmlns='http://cisco.com/yang/cisco-ia'>true</syncing>\n<syncs-pending xmlns='http://cisco.com/yang/cisco-ia'>true</syncs-pending>\n<running-datastore-locked xmlns='http://cisco.com/yang/cisco-ia'>false</running-datastore-locked>\n</rpc-reply>"""}
2026-01-08T13:59:38.614940965Z DEBUG  DeviceInstance [local-iosxe]: netclics.DeviceInstance[-56]: is-syncing result - {'syncing':'true', 'is_syncing':'True'}
2026-01-08T13:59:38.615019919Z DEBUG  DeviceInstance [local-iosxe]: netclics.DeviceInstance[-56]: IOS-XE still syncing, polling again - {'attempt':4}
2026-01-08T13:59:39.617476286Z DEBUG  DeviceInstance [local-iosxe]: netclics.DeviceInstance[-56]: Reusing existing NETCONF client for conversion
2026-01-08T13:59:39.617758939Z DEBUG  netconf.Client[-29301]: Sending RPC - {'message-id':'7', 'content':<xml.Node object at 0x730cf6502fa0>}
2026-01-08T13:59:39.617887284Z TRACE  netconf.Client[-29301]: Sending chunk - {'chunk_size':126, 'chunk':b'<rpc xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\" message-id=\"7\"><is-syncing xmlns=\"http://cisco.com/yang/cisco-ia\"/></rpc>'}
2026-01-08T13:59:39.646752414Z TRACE  netconf.Client[-29301]: MSG: - {'msg':"""<?xml version="1.0" encoding="UTF-8"?>\n<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="7"><result xmlns='http://cisco.com/yang/cisco-ia'>Sync in progress. Reason: 'vrf forwarding Mgmt-intf ' CLI</result>\n<syncing xmlns='http://cisco.com/yang/cisco-ia'>true</syncing>\n<syncs-pending xmlns='http://cisco.com/yang/cisco-ia'>true</syncs-pending>\n<running-datastore-locked xmlns='http://cisco.com/yang/cisco-ia'>false</running-datastore-locked>\n</rpc-reply>"""}
2026-01-08T13:59:39.647295781Z DEBUG  DeviceInstance [local-iosxe]: netclics.DeviceInstance[-56]: is-syncing result - {'syncing':'true', 'is_syncing':'True'}
2026-01-08T13:59:39.647445939Z DEBUG  DeviceInstance [local-iosxe]: netclics.DeviceInstance[-56]: IOS-XE still syncing, polling again - {'attempt':5}
2026-01-08T13:59:40.646746437Z DEBUG  DeviceInstance [local-iosxe]: netclics.DeviceInstance[-56]: Reusing existing NETCONF client for conversion
2026-01-08T13:59:40.646984963Z DEBUG  netconf.Client[-29301]: Sending RPC - {'message-id':'8', 'content':<xml.Node object at 0x730cf68e0050>}
2026-01-08T13:59:40.647104624Z TRACE  netconf.Client[-29301]: Sending chunk - {'chunk_size':126, 'chunk':b'<rpc xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\" message-id=\"8\"><is-syncing xmlns=\"http://cisco.com/yang/cisco-ia\"/></rpc>'}
2026-01-08T13:59:40.706533443Z TRACE  netconf.Client[-29301]: MSG: - {'msg':"""<?xml version="1.0" encoding="UTF-8"?>\n<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="8"><result xmlns='http://cisco.com/yang/cisco-ia'>Sync in progress. Reason: 'vrf forwarding Mgmt-intf ' CLI</result>\n<syncing xmlns='http://cisco.com/yang/cisco-ia'>true</syncing>\n<syncs-pending xmlns='http://cisco.com/yang/cisco-ia'>true</syncs-pending>\n<running-datastore-locked xmlns='http://cisco.com/yang/cisco-ia'>false</running-datastore-locked>\n</rpc-reply>"""}
2026-01-08T13:59:40.707155037Z DEBUG  DeviceInstance [local-iosxe]: netclics.DeviceInstance[-56]: is-syncing result - {'syncing':'true', 'is_syncing':'True'}
2026-01-08T13:59:40.707229747Z DEBUG  DeviceInstance [local-iosxe]: netclics.DeviceInstance[-56]: IOS-XE still syncing, polling again - {'attempt':6}
2026-01-08T13:59:41.706580247Z DEBUG  DeviceInstance [local-iosxe]: netclics.DeviceInstance[-56]: Reusing existing NETCONF client for conversion
2026-01-08T13:59:41.706831571Z DEBUG  netconf.Client[-29301]: Sending RPC - {'message-id':'9', 'content':<xml.Node object at 0x730cf61e47d0>}
2026-01-08T13:59:41.706941931Z TRACE  netconf.Client[-29301]: Sending chunk - {'chunk_size':126, 'chunk':b'<rpc xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\" message-id=\"9\"><is-syncing xmlns=\"http://cisco.com/yang/cisco-ia\"/></rpc>'}
2026-01-08T13:59:41.746629523Z TRACE  netconf.Client[-29301]: MSG: - {'msg':"""<?xml version="1.0" encoding="UTF-8"?>\n<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="9"><result xmlns='http://cisco.com/yang/cisco-ia'>Sync in progress. Reason: IOS configuration modified directly by user</result>\n<syncing xmlns='http://cisco.com/yang/cisco-ia'>true</syncing>\n<syncs-pending xmlns='http://cisco.com/yang/cisco-ia'>true</syncs-pending>\n<running-datastore-locked xmlns='http://cisco.com/yang/cisco-ia'>false</running-datastore-locked>\n</rpc-reply>"""}
2026-01-08T13:59:41.747213761Z DEBUG  DeviceInstance [local-iosxe]: netclics.DeviceInstance[-56]: is-syncing result - {'syncing':'true', 'is_syncing':'True'}
2026-01-08T13:59:41.747318478Z DEBUG  DeviceInstance [local-iosxe]: netclics.DeviceInstance[-56]: IOS-XE still syncing, polling again - {'attempt':7}
2026-01-08T13:59:42.746523077Z DEBUG  DeviceInstance [local-iosxe]: netclics.DeviceInstance[-56]: Reusing existing NETCONF client for conversion
2026-01-08T13:59:42.746783074Z DEBUG  netconf.Client[-29301]: Sending RPC - {'message-id':'10', 'content':<xml.Node object at 0x730cf61e4190>}
2026-01-08T13:59:42.746940042Z TRACE  netconf.Client[-29301]: Sending chunk - {'chunk_size':127, 'chunk':b'<rpc xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\" message-id=\"10\"><is-syncing xmlns=\"http://cisco.com/yang/cisco-ia\"/></rpc>'}
2026-01-08T13:59:42.759114374Z TRACE  netconf.Client[-29301]: MSG: - {'msg':"""<?xml version="1.0" encoding="UTF-8"?>\n<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="10"><result xmlns='http://cisco.com/yang/cisco-ia'>No sync in progress</result>\n<syncing xmlns='http://cisco.com/yang/cisco-ia'>false</syncing>\n<syncs-pending xmlns='http://cisco.com/yang/cisco-ia'>false</syncs-pending>\n<running-datastore-locked xmlns='http://cisco.com/yang/cisco-ia'>false</running-datastore-locked>\n</rpc-reply>"""}
2026-01-08T13:59:42.759706471Z DEBUG  DeviceInstance [local-iosxe]: netclics.DeviceInstance[-56]: is-syncing result - {'syncing':'false', 'is_syncing':'False'}
2026-01-08T13:59:42.759796785Z INFO   DeviceInstance [local-iosxe]: netclics.DeviceInstance[-56]: IOS-XE sync complete - {'attempts':8}
2026-01-08T13:59:42.759864874Z INFO   DeviceInstance [local-iosxe]: netclics.DeviceInstance[-56]: Getting NETCONF config with parsing
2026-01-08T13:59:42.759910724Z DEBUG  DeviceInstance [local-iosxe]: netclics.DeviceInstance[-56]: Reusing existing NETCONF client for conversion
2
</pre>
</details>