### PR TITLE
Expand HTTP server with static content handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ Notes:
 - `--http-port 0` disables HTTP.
 - HTTPS is enabled only when `--https-port`, `--tls-cert`, and `--tls-key` are all provided.
 
+## Static file server, ACME HTTP-01 challenge
+
+To serve static files for non-API GET paths:
+
+```bash
+out/bin/netclics --static-dir /path/to/public_html
+```
+
+This is also useful for integrating NETCLICS with [certbot](https://certbot.eff.org). If you configure certbot to use the same web root using the option `--webroot /path/to/public_html`, then it will automatically create the `/.well-known/token/...` response for the HTTP-01 challenge.
+
 ## Configuration File
 
 NETCLICS loads configuration from `config/netclics.json` by default.

--- a/src/netclics.act
+++ b/src/netclics.act
@@ -17,6 +17,7 @@ import yang.xml
 import container_manager
 import schema_filter
 import netclics_config
+import static_files
 
 
 # Constant for the wildcard (all modules) default module-set
@@ -2676,7 +2677,7 @@ actor MCPServer(convert_fn: action(ConvertRequest, action(?(base_config: str, st
             _send_error_response(request_id, MCP_INTERNAL_ERROR, str(e), respond, "list_instances")
 
 actor WebServ(listen_cap: net.TCPListenCap, http_port: ?int, director, log_handler: logging.Handler,
-              config_path: str, read_cap: file.ReadFileCap,
+              config_path: str, read_cap: file.ReadFileCap, static_file_server: ?static_files.StaticFileServer = None,
               https_port: ?int = None, tls_cert_pem: ?bytes = None, tls_key_pem: ?bytes = None):
     logh = logging.Handler("WebServ")
     logh.set_handler(log_handler)
@@ -2792,6 +2793,13 @@ actor WebServ(listen_cap: net.TCPListenCap, http_port: ?int, director, log_handl
                 respond(200, {"Content-Type": "application/json"}, response_json)
 
         else:
+            _static_file_server = static_file_server
+            if _static_file_server is not None:
+                static_response = _static_file_server.maybe_serve(request.method, request.path)
+                if static_response is not None:
+                    status_code, headers, body = static_response
+                    respond(status_code, headers, body)
+                    return
             respond(404, {"Content-Type": "application/json"}, json.encode({"error": "Not found"}))
 
     def _on_http_server_request(server, request, respond):
@@ -2842,6 +2850,7 @@ actor main(env: Env):
         p.add_option("http-port", "int", default=8080, help="HTTP listen port (set to 0 to disable)")
         p.add_option("https-port", "int", default=0, help="HTTPS listen port (set to 0 to disable)")
         p.add_option("config", "str", default=netclics_config.DEFAULT_CONFIG_PATH, help="Path to config JSON file")
+        p.add_option("static-dir", "str", default="", help="Directory to serve static files from (disabled when empty)")
         p.add_option("tls-cert", "str", default="", help="Path to TLS certificate PEM file")
         p.add_option("tls-key", "str", default="", help="Path to TLS private key PEM file")
         return p.parse(env.argv)
@@ -2861,6 +2870,7 @@ actor main(env: Env):
     http_port = args.get_int("http-port")
     https_port = args.get_int("https-port")
     config_path = args.get_str("config")
+    static_dir = args.get_str("static-dir")
     tls_cert_path = args.get_str("tls-cert")
     tls_key_path = args.get_str("tls-key")
 
@@ -2896,11 +2906,21 @@ actor main(env: Env):
             print("ERROR: HTTPS port {https_port} configured but --tls-cert and --tls-key were not both provided", err=True)
             env.exit(1)
 
+    static_file_server: ?static_files.StaticFileServer = None
+    if static_dir != "":
+        try:
+            initialized_static_server = static_files.StaticFileServer(file_cap, read_cap, static_dir)
+            static_file_server = initialized_static_server
+            _log.info("Enabled static file serving", {"directory": initialized_static_server.get_root_dir()})
+        except Exception as e:
+            print("ERROR: Failed to initialize static directory {static_dir}: {str(e)}", err=True)
+            env.exit(1)
+
     _log.info("Configuration file watcher will bootstrap and reload config", {"config_path": config_path})
 
     director = Director(env.cap, proc_cap, log_handler)
     config_change_watcher = netclics_config.ConfigChangeWatcher(read_cap, config_path, director.set_config, log_handler)
-    webs = WebServ(listen_cap, http_port if http_port > 0 else None, director, log_handler, config_path, read_cap, https_port if https_port > 0 else None, tls_cert_pem, tls_key_pem)
+    webs = WebServ(listen_cap, http_port if http_port > 0 else None, director, log_handler, config_path, read_cap, static_file_server, https_port if https_port > 0 else None, tls_cert_pem, tls_key_pem)
     if https_port is not None and tls_cert_pem is not None and tls_key_pem is not None:
         _log.info("NETCLICS started", {"http_port": http_port, "https_port": https_port})
     else:

--- a/src/static_files.act
+++ b/src/static_files.act
@@ -1,0 +1,133 @@
+import file
+import uri
+
+
+def _normalize_request_path(path: str) -> str:
+    parsed_path, _ = uri.parse_path(path)
+    path_without_query = parsed_path if parsed_path is not None else "/"
+    if "\\" in path_without_query:
+        raise ValueError("Backslash not allowed in URI path")
+
+    # Canonicalize empty segments
+    return "/".join([part for part in path_without_query.split("/") if part not in {"", "."}])
+
+
+def _is_under_root(root_dir: str, absolute_path: str) -> bool:
+    if root_dir == "/":
+        return absolute_path.startswith("/")
+    return absolute_path == root_dir or absolute_path.startswith(root_dir + "/")
+
+
+def _guess_content_type(path: str) -> str:
+    lower = path.lower()
+    if lower.endswith(".html") or lower.endswith(".htm"):
+        return "text/html; charset=utf-8"
+    if lower.endswith(".css"):
+        return "text/css; charset=utf-8"
+    if lower.endswith(".js") or lower.endswith(".mjs"):
+        return "application/javascript; charset=utf-8"
+    if lower.endswith(".json"):
+        return "application/json; charset=utf-8"
+    if lower.endswith(".txt"):
+        return "text/plain; charset=utf-8"
+    if lower.endswith(".xml"):
+        return "application/xml; charset=utf-8"
+    if lower.endswith(".svg"):
+        return "image/svg+xml"
+    if lower.endswith(".ico"):
+        return "image/x-icon"
+    return "application/octet-stream"
+
+
+def _text_response(status_code: int, body: str) -> (int, dict[str, str], str):
+    return (status_code, {"Content-Type": "text/plain; charset=utf-8"}, body)
+
+
+def _resolve_target_path(fs: file.FS, root_dir: str, candidate_path: str) -> (int, ?str):
+    if not _is_under_root(root_dir, candidate_path):
+        return 403, None
+
+    try:
+        st = fs.stat(candidate_path)
+        if st.is_dir():
+            index_path = file.resolve_relative_path(candidate_path, "index.html")
+            st = fs.stat(index_path)
+            if not st.is_file():
+                return 404, None
+            return 200, index_path
+
+        if not st.is_file():
+            return 404, None
+
+        return 200, candidate_path
+    except OSError:
+        return 404, None
+    except ValueError:
+        return 403, None
+
+
+def _resolve_configured_root(fs: file.FS, configured_root_dir: str) -> str:
+    resolved = configured_root_dir
+    if not resolved.startswith("/"):
+        resolved = file.resolve_relative_path(fs.cwd(), resolved)
+    resolved = resolved.rstrip("/")
+    if resolved == "":
+        resolved = "/"
+
+    try:
+        st = fs.stat(resolved)
+        if not st.is_dir():
+            raise ValueError("Static directory is not a directory: " + resolved)
+    except OSError:
+        raise ValueError("Static directory does not exist: " + resolved)
+
+    return resolved
+
+
+actor StaticFileServer(file_cap: file.FileCap, read_cap: file.ReadFileCap, configured_root_dir: str):
+    var fs = file.FS(file_cap)
+    var root_dir = _resolve_configured_root(fs, configured_root_dir)
+
+    def get_root_dir() -> str:
+        return root_dir
+
+    def maybe_serve(request_method: str, request_path: str) -> ?(int, dict[str, str], str):
+        if request_method != "GET":
+            return None
+
+        normalized = ""
+        try:
+            normalized = _normalize_request_path(request_path)
+        except ValueError:
+            return _text_response(400, "Bad request")
+        relative_path = normalized[1:] if normalized.startswith("/") else normalized
+        if relative_path == "":
+            relative_path = "index.html"
+
+        absolute_path = ""
+        try:
+            absolute_path = file.resolve_relative_path(root_dir, relative_path)
+        except ValueError:
+            return _text_response(403, "Forbidden")
+
+        target_status, target_path = _resolve_target_path(fs, root_dir, absolute_path)
+        if target_status == 403:
+            return _text_response(403, "Forbidden")
+        elif target_status == 404:
+            return _text_response(404, "Not found")
+        elif target_path is not None:
+            raw_data = b""
+            try:
+                reader = file.ReadFile(read_cap, target_path)
+                raw_data = reader.read()
+                reader.close()
+            except OSError:
+                return _text_response(404, "Not found")
+            except Exception:
+                return _text_response(500, "Internal server error")
+
+            try:
+                decoded_body = raw_data.decode()
+                return (200, {"Content-Type": _guess_content_type(target_path)}, decoded_body)
+            except Exception:
+                return _text_response(415, "Unsupported media type")


### PR DESCRIPTION
This will be initially used to integrate with certbot to do the HTTP-01 challenge for certificate renewal, while the netclics server is running. Later it will fit in nicely as a component in the HTTP router for serving static files, like the dashboard.