### PR TITLE
Automatically reload config file on change

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -124,10 +124,6 @@ platforms:
 instances:
     curl {{NETCLICS_CURL_OPTS}} -s {{NETCLICS_BASE_URL}}/api/v1/instances | jq .
 
-# Reload config from disk without restarting NETCLICS
-reload-config:
-    curl {{NETCLICS_CURL_OPTS}} -s -X POST {{NETCLICS_BASE_URL}}/api/v1/config/reload | jq .
-
 # Convert NETCONF/XML to NETCONF/XML, roundtrip via crpd
 test-xml-to-xml-crpd:
     #!/usr/bin/env bash

--- a/README.md
+++ b/README.md
@@ -27,14 +27,4 @@ Use a different file with:
 out/bin/netclics --config /path/to/netclics.json
 ```
 
-After editing the config file, reload it without restarting:
-
-```bash
-curl -s -X POST http://localhost:8080/api/v1/config/reload | jq .
-```
-
-Or with Just:
-
-```bash
-just reload-config
-```
+After editing the config file, save it and it will be automatically reloaded.

--- a/src/netclics.act
+++ b/src/netclics.act
@@ -2157,18 +2157,13 @@ actor Director(auth: WorldCap, proc_cap: process.ProcessCap, log_handler: loggin
     logh.set_handler(log_handler)
     _log = logging.Logger(logh)
 
-    def set_config(conf: netclics_config.SystemConfig):
-        container_mgr = container_manager.ContainerManager(proc_cap, log_handler)
-        dm = DeviceManager(conf, container_mgr, auth, log_handler)
-        dm.initialize_min_instances()
-        device_manager = dm
-        _log.info("Director initialized")
-
-    def reload_config(conf: netclics_config.SystemConfig, cb: action(?Exception) -> None):
+    def set_config(conf: netclics_config.SystemConfig, cb: action(?Exception) -> None):
+        if device_manager is None:
+            container_mgr = container_manager.ContainerManager(proc_cap, log_handler)
+            device_manager = DeviceManager(conf, container_mgr, auth, log_handler)
+            _log.info("Director initialized")
         if device_manager is not None:
             device_manager.apply_config(conf, cb)
-            return
-        cb(Exception("Director not initialized"))
 
     def convert(request: ConvertRequest, callback: action(?(base_config: str, steps: list[(input: str, config: str, diff: str)]), ?Exception) -> None):
         """Process a conversion request"""
@@ -2743,26 +2738,6 @@ actor WebServ(listen_cap: net.TCPListenCap, http_port: ?int, director, log_handl
                 error_dict = {"success": False, "error": str(e)}
                 error_str = json.encode(error_dict)
                 respond(400, {"Content-Type": "application/json"}, error_str)
-        # POST /api/v1/config/reload - Reload configuration from disk
-        elif request.path == "/api/v1/config/reload" and request.method == "POST":
-            def on_reload_done(error: ?Exception):
-                if error is None:
-                    response = {"success": True}
-                    respond(200, {"Content-Type": "application/json"}, json.encode(response))
-                else:
-                    response = {"success": False, "error": str(error)}
-                    respond(500, {"Content-Type": "application/json"}, json.encode(response))
-
-            _log.info("Reloading configuration from disk", {"path": config_path})
-            try:
-                new_config = netclics_config.load_config_from_file(read_cap, config_path)
-            except Exception as e:
-                error_dict = {"success": False, "error": str(e)}
-                error_str = json.encode(error_dict)
-                respond(400, {"Content-Type": "application/json"}, error_str)
-                return
-            else:
-                director.reload_config(new_config, on_reload_done)
         # GET /api/v1/instances - List all running instances
         elif request.path == "/api/v1/instances" and request.method == "GET":
             # Get actual instances from director
@@ -2889,16 +2864,9 @@ actor main(env: Env):
     tls_cert_path = args.get_str("tls-cert")
     tls_key_path = args.get_str("tls-key")
 
-    # Load configuration
     file_cap = file.FileCap(env.cap)
     read_cap = file.ReadFileCap(file_cap)
-    maybe_config: ?netclics_config.SystemConfig = None
-    try:
-        maybe_config = netclics_config.load_config_from_file(read_cap, config_path)
-    except Exception as e:
-        print(f"ERROR: Failed to load config file {config_path}: {str(e)}", err=True)
-        env.exit(1)
-    config = expect(maybe_config, "loaded config")
+
     # Create logging handler
     log_handler = logging.Handler(None)
     log_handler.add_sink(logging.StdoutSink())
@@ -2928,10 +2896,10 @@ actor main(env: Env):
             print("ERROR: HTTPS port {https_port} configured but --tls-cert and --tls-key were not both provided", err=True)
             env.exit(1)
 
-    _log.info("Loaded platform configurations", {"platform_count": len(config.platforms), "config_path": config_path})
+    _log.info("Configuration file watcher will bootstrap and reload config", {"config_path": config_path})
 
     director = Director(env.cap, proc_cap, log_handler)
-    director.set_config(config)
+    config_change_watcher = netclics_config.ConfigChangeWatcher(read_cap, config_path, director.set_config, log_handler)
     webs = WebServ(listen_cap, http_port if http_port > 0 else None, director, log_handler, config_path, read_cap, https_port if https_port > 0 else None, tls_cert_pem, tls_key_pem)
     if https_port is not None and tls_cert_pem is not None and tls_key_pem is not None:
         _log.info("NETCLICS started", {"http_port": http_port, "https_port": https_port})

--- a/src/netclics_config.act
+++ b/src/netclics_config.act
@@ -1,7 +1,9 @@
 import file
 import json
+import logging
 
 DEFAULT_CONFIG_PATH = "config/netclics.json"
+DEFAULT_CONFIG_RELOAD_POLL_SECONDS = 2.0
 
 class InstanceSpec(object):
     """Specification for a static instance (physical device, VM, or pre-existing container)"""
@@ -206,11 +208,52 @@ def parse_system_config(data: dict[str, ?value]) -> SystemConfig:
     raise ValueError("Config must contain 'platforms' list")
 
 
-def load_config_from_file(read_cap: file.ReadFileCap, path: str) -> SystemConfig:
-    reader = file.ReadFile(read_cap, path)
-    raw = reader.read()
-    reader.close()
-    decoded = json.decode(raw.decode())
-    if isinstance(decoded, dict):
-        return parse_system_config(decoded)
-    raise ValueError("Config file must be a JSON object")
+actor ConfigChangeWatcher(read_cap: file.ReadFileCap,
+                          config_path: str,
+                          reload_config_fn: action(SystemConfig, action(?Exception) -> None) -> None,
+                          log_handler: logging.Handler,
+                          poll_interval_seconds: float = DEFAULT_CONFIG_RELOAD_POLL_SECONDS):
+    """
+    Poll config file for changes and trigger reloads.
+    TODO: switch to inotify when Acton supports it.
+    """
+    logh = logging.Handler("ConfigChangeWatcher")
+    logh.set_handler(log_handler)
+    _log = logging.Logger(logh)
+
+    var last_snapshot: ?str = None
+
+    def _poll():
+        current_text = ""
+        try:
+            reader = file.ReadFile(read_cap, config_path)
+            raw = reader.read()
+            reader.close()
+            current_text = raw.decode()
+        except Exception as e:
+            _log.warning("Failed to read config file while polling", {"path": config_path, "error": str(e)})
+            after poll_interval_seconds: _poll()
+            return
+
+        if last_snapshot != current_text:
+            _log.info("Detected config file change", {"path": config_path})
+            last_snapshot = current_text
+
+            try:
+                decoded = json.decode(current_text)
+                new_config = parse_system_config(decoded)
+            except Exception as e:
+                _log.error("Config file changed but decode failed", {"path": config_path, "error": str(e)})
+            else:
+                def on_reload_done(error: ?Exception):
+                    if error is None:
+                        _log.info("Reloaded configuration after file change", {"path": config_path})
+                    else:
+                        _log.error("Failed to reload configuration after file change", {"path": config_path, "error": str(error)})
+
+                reload_config_fn(new_config, on_reload_done)
+
+        after poll_interval_seconds: _poll()
+
+    _log.info("Starting config change watcher", {"path": config_path, "poll_interval_seconds": poll_interval_seconds})
+    _poll()


### PR DESCRIPTION
A watcher polls the config file for changes in the background. When changed, the new file is immediately reloaded and changes applied. Once Acton supports inotify for watching files we can replace this with the more optimal solution.