### PR TITLE
Include touched schema paths in adata printouts

### DIFF
--- a/Build.act
+++ b/Build.act
@@ -8,13 +8,13 @@ dependencies = {
     ),
     "netconf": (
         repo_url="https://github.com/orchestron-orchestrator/netconf.git",
-        url="https://github.com/orchestron-orchestrator/netconf/archive/2c7a5050881eb6e19d06e740add06699d9f5ad06.zip",
-        hash="N-V-__8AACCwAgCDCdukQxaYQwCoLtP9JslqTv8bnSHwfBMW"
+        url="https://github.com/orchestron-orchestrator/netconf/archive/a15adeba1399d2a0e073856836c6378622b08595.zip",
+        hash="N-V-__8AAFKwAgCUXadRFGEvRQsHeljRzOxDHb8lBkmf1p9O"
     ),
     "yang": (
         repo_url="https://github.com/orchestron-orchestrator/acton-yang.git",
-        url="https://github.com/orchestron-orchestrator/acton-yang/archive/f0ee31fcf61754d9fa6d0872149b3433137d00a1.zip",
-        hash="N-V-__8AAJ4_IQDRHd4-0vQoIL4cYmBTNi7_mkF69Y3ICfbR"
+        url="https://github.com/orchestron-orchestrator/acton-yang/archive/cb338ccffdc7b296558aab5479a2dc05f0ff0fed.zip",
+        hash="N-V-__8AAF-rIQDUTCVgeAqZIgkVoPRaugeV6xBOsidbWVKj"
     )
 }
 zig_dependencies = {}

--- a/src/netclics.act
+++ b/src/netclics.act
@@ -779,16 +779,11 @@ actor DeviceInstance(auth: WorldCap, log_handler: logging.Handler, platform_name
         def format_gdata_output(gdata: yang.gdata.Node, target_format: str) -> str:
             """Format parsed gdata to the requested output format"""
             if target_format == "json":
-                return gdata.to_jsonstr()
+                return gdata.to_yang_jsonstr()
             elif target_format == "acton-gdata":
                 return gdata.prsrc()
             elif target_format == "acton-adata":
-                compiled_schema, error = get_compiled_schema(request.module_set)
-                if compiled_schema is not None:
-                    return yang.data.pradata(compiled_schema, gdata, loose=True, self_name="dev")
-                else:
-                    _log.warning("No compiled schema for adata conversion, using gdata", {"error": compiled_schema})
-                    return gdata.prsrc()
+                return _format_adata_with_paths(gdata, request.module_set, "adata conversion")
             elif target_format in ["netconf", "xml"]:
                 return gdata.to_xmlstr(pretty=True)
             else:
@@ -1392,6 +1387,22 @@ actor DeviceInstance(auth: WorldCap, log_handler: logging.Handler, platform_name
 
         _get_or_create_cli_client(on_client_success, on_client_error)
 
+    def _format_adata_with_paths(gdata: yang.gdata.Node, module_set: str, context: str) -> str:
+        """Format gdata as adata and append touched schema paths."""
+        compiled_schema, error = get_compiled_schema(module_set)
+        if compiled_schema is not None:
+            adata_output = yang.data.pradata(compiled_schema, gdata, loose=True, self_name="dev")
+            touched_paths = yang.data.prpaths(compiled_schema, gdata)
+            if len(touched_paths) == 0:
+                return adata_output
+
+            path_lines = "\n".join(["    {repr(p)}," for p in touched_paths])
+            touched_paths_repr = "\n\n=== Touched Schema Paths ===\n[\n{path_lines}\n]"
+            return adata_output + touched_paths_repr
+        else:
+            _log.warning("No compiled schema for {context}, using gdata", {"module_set": module_set, "error": error})
+            return gdata.prsrc()
+
     def _compute_gdata_diff(base_gdata: yang.gdata.Node, final_gdata: yang.gdata.Node, target_format: str, module_set: str) -> str:
         """Compute diff between base and final gdata configs"""
         try:
@@ -1401,17 +1412,11 @@ actor DeviceInstance(auth: WorldCap, log_handler: logging.Handler, platform_name
             if diff_result is not None:
                 # Convert diff to appropriate format based on target_format
                 if target_format == "json":
-                    return diff_result.to_jsonstr()
+                    return diff_result.to_yang_jsonstr()
                 elif target_format == "acton-gdata":
                     return diff_result.prsrc()
                 elif target_format == "acton-adata":
-                    # Convert diff to adata format if schema is available
-                    compiled_schema, error = get_compiled_schema(module_set)
-                    if compiled_schema is not None:
-                        return yang.data.pradata(compiled_schema, diff_result, loose=True, self_name="dev")
-                    else:
-                        _log.warning("No compiled schema for adata diff conversion, using prsrc", {"error": error})
-                        return diff_result.prsrc()
+                    return _format_adata_with_paths(diff_result, module_set, "adata diff conversion")
                 elif target_format in ["netconf", "xml"]:
                     # For XML formats, return the diff as XML string
                     return diff_result.to_xmlstr()


### PR DESCRIPTION
Include touched schema paths in the adata output. This is useful for creating / maintaining a schema pruning filter.

The adata outputs now look like this:

```
=== Configuration Diff ===
# Top node: /
dev = root()

# List /configuration/interfaces/interface element: ge-0/0/4
interface_element = dev.configuration.interfaces.interface.create('ge-0/0/4')
interface_element.description = 'CLI to adata test'

# touched schema paths:
# [
#     '/configuration/interfaces/interface/description',
#     '/configuration/interfaces/interface/name',
# ] 
```